### PR TITLE
Update product-shell-detail.component.html

### DIFF
--- a/APM-Start v14/src/app/products/product-shell/product-shell-detail.component.html
+++ b/APM-Start v14/src/app/products/product-shell/product-shell-detail.component.html
@@ -1,5 +1,5 @@
 <div class='card'>
-  <div class='card-heading'>
+  <div class='card-header'>
     Product Detail: {{product?.productName}}
   </div>
 


### PR DESCRIPTION
Minor change request: There is a typo in the template of product-shell-detail.component, under the APM-Start v14. The class for the card header should read 'card-header' in order to display the Bootstrap styling.